### PR TITLE
add account to accountTransaction

### DIFF
--- a/exercise/handle_reissued_deposit.rb
+++ b/exercise/handle_reissued_deposit.rb
@@ -10,7 +10,7 @@ deposit.amount = 11
 deposit.time = '2000-01-01T11:11:11.000Z'
 
 command_stream_name = "account:command-#{account_id}"
-transaction_stream_name = "accountTransaction-#{deposit_id}"
+transaction_stream_name = "account-accountTransaction-#{deposit_id}"
 
 
 store = Store.build

--- a/exercise/handle_reissued_withdraw.rb
+++ b/exercise/handle_reissued_withdraw.rb
@@ -22,7 +22,7 @@ withdraw.amount = 11
 withdraw.time = '2000-01-01T11:11:11.000Z'
 
 command_stream_name = "account:command-#{account_id}"
-transaction_stream_name = "accountTransaction-#{withdrawal_id}"
+transaction_stream_name = "account-accountTransaction-#{withdrawal_id}"
 
 
 store = Store.build


### PR DESCRIPTION
This stream name should be ```"account-accountTransaction-#{deposit_id}"```  otherwise balance will always be 0 when running this exercise.  Or we could remove `stream_name` from the the Deposit and and Withdraw handlers and use plain `"accountTransaction-#{deposit_id}"`