### PR TITLE
Add missing asserts

### DIFF
--- a/test/automated/handle_commands/close/closed.rb
+++ b/test/automated/handle_commands/close/closed.rb
@@ -19,7 +19,7 @@ context "Handle Commands" do
       writer = handler.write
 
       closed = writer.one_message do |event|
-        event.instance_of?(Messages::Events::Closed)
+        assert(event.instance_of?(Messages::Events::Closed))
       end
 
       test "Closed Event is Written" do

--- a/test/automated/handle_commands/close/expected_version.rb
+++ b/test/automated/handle_commands/close/expected_version.rb
@@ -18,7 +18,7 @@ context "Handle Commands" do
       writer = handler.write
 
       closed = writer.one_message do |event|
-        event.instance_of?(Messages::Events::Closed)
+        assert(event.instance_of?(Messages::Events::Closed))
       end
 
       test "Is entity version" do

--- a/test/automated/handle_commands/close/ignored.rb
+++ b/test/automated/handle_commands/close/ignored.rb
@@ -16,7 +16,7 @@ context "Handle Commands" do
       writer = handler.write
 
       closed = writer.one_message do |event|
-        event.instance_of?(Messages::Events::Closed)
+        assert(event.instance_of?(Messages::Events::Closed))
       end
 
       test "Closed Event is not Written" do

--- a/test/automated/handle_commands/open/expected_version.rb
+++ b/test/automated/handle_commands/open/expected_version.rb
@@ -18,7 +18,7 @@ context "Handle Commands" do
       writer = handler.write
 
       opened = writer.one_message do |event|
-        event.instance_of?(Messages::Events::Opened)
+        assert(event.instance_of?(Messages::Events::Opened))
       end
 
       test "Is entity version" do

--- a/test/automated/handle_commands/open/ignored.rb
+++ b/test/automated/handle_commands/open/ignored.rb
@@ -16,7 +16,7 @@ context "Handle Commands" do
       writer = handler.write
 
       opened = writer.one_message do |event|
-        event.instance_of?(Messages::Events::Opened)
+        assert(event.instance_of?(Messages::Events::Opened))
       end
 
       test "Opened Event is not Written" do

--- a/test/automated/handle_commands/open/opened.rb
+++ b/test/automated/handle_commands/open/opened.rb
@@ -20,7 +20,7 @@ context "Handle Commands" do
       writer = handler.write
 
       opened = writer.one_message do |event|
-        event.instance_of?(Messages::Events::Opened)
+        assert(event.instance_of?(Messages::Events::Opened))
       end
 
       test "Opened Event is Written" do

--- a/test/automated/handle_commands/transactions/deposit/deposited.rb
+++ b/test/automated/handle_commands/transactions/deposit/deposited.rb
@@ -22,7 +22,7 @@ context "Handle Commands" do
         writer = handler.write
 
         deposited = writer.one_message do |event|
-          event.instance_of?(Messages::Events::Deposited)
+          assert(event.instance_of?(Messages::Events::Deposited))
         end
 
         test "Deposited Event is Written" do

--- a/test/automated/handle_commands/transactions/deposit/expected_version.rb
+++ b/test/automated/handle_commands/transactions/deposit/expected_version.rb
@@ -19,7 +19,7 @@ context "Handle Commands" do
         writer = handler.write
 
         deposited = writer.one_message do |event|
-          event.instance_of?(Messages::Events::Deposited)
+          assert(event.instance_of?(Messages::Events::Deposited))
         end
 
         test "Is entity version" do

--- a/test/automated/handle_commands/transactions/deposit/ignored.rb
+++ b/test/automated/handle_commands/transactions/deposit/ignored.rb
@@ -19,7 +19,7 @@ context "Handle Commands" do
         writer = handler.write
 
         deposited = writer.one_message do |event|
-          event.instance_of?(Messages::Events::Deposited)
+          assert(event.instance_of?(Messages::Events::Deposited))
         end
 
         test "Deposited Event is not Written" do

--- a/test/automated/handle_commands/transactions/withdraw/expected_version.rb
+++ b/test/automated/handle_commands/transactions/withdraw/expected_version.rb
@@ -19,7 +19,7 @@ context "Handle Commands" do
         writer = handler.write
 
         withdrawn = writer.one_message do |event|
-          event.instance_of?(Messages::Events::Withdrawn)
+          assert(event.instance_of?(Messages::Events::Withdrawn))
         end
 
         test "Is entity version" do

--- a/test/automated/handle_commands/transactions/withdraw/rejected.rb
+++ b/test/automated/handle_commands/transactions/withdraw/rejected.rb
@@ -26,7 +26,7 @@ context "Handle Commands" do
         writer = handler.write
 
         withdrawal_rejected = writer.one_message do |event|
-          event.instance_of?(Messages::Events::WithdrawalRejected)
+          assert(event.instance_of?(Messages::Events::WithdrawalRejected))
         end
 
         test "Withdrawal Rejected Event is Written" do

--- a/test/automated/handle_commands/transactions/withdraw/withdrawn.rb
+++ b/test/automated/handle_commands/transactions/withdraw/withdrawn.rb
@@ -26,7 +26,7 @@ context "Handle Commands" do
         writer = handler.write
 
         withdrawn = writer.one_message do |event|
-          event.instance_of?(Messages::Events::Withdrawn)
+          assert(event.instance_of?(Messages::Events::Withdrawn))
         end
 
         test "Withdrawn Event is Written" do


### PR DESCRIPTION
Added missing assert to automated tests for command handlers

At least they appear to be missing. There's a check on the instance of each message created, but no assert on the value the check returns.